### PR TITLE
Vote mute

### DIFF
--- a/api/src/main/java/com/alttd/chat/config/Config.java
+++ b/api/src/main/java/com/alttd/chat/config/Config.java
@@ -551,4 +551,12 @@ public final class Config {
         DEATH_MESSAGES_MAX_PER_PERIOD = getInt("death-messages.max-per-period", DEATH_MESSAGES_MAX_PER_PERIOD);
         DEATH_MESSAGES_LIMIT_PERIOD_MINUTES = getInt("death-messages.limit-period-minutes", DEATH_MESSAGES_LIMIT_PERIOD_MINUTES);
     }
+
+    public static long CHAT_LOG_DELETE_OLDER_THAN_DAYS = 31;
+    public static long CHAT_LOG_SAVE_DELAY_MINUTES = 5;
+
+    private static void chatLogSettings() {
+        CHAT_LOG_DELETE_OLDER_THAN_DAYS = getLong("chat-log.delete-older-than-days", CHAT_LOG_DELETE_OLDER_THAN_DAYS);
+        CHAT_LOG_SAVE_DELAY_MINUTES = getLong("chat-log.save-delay-minutes", CHAT_LOG_SAVE_DELAY_MINUTES);
+    }
 }

--- a/api/src/main/java/com/alttd/chat/database/ChatLogQueries.java
+++ b/api/src/main/java/com/alttd/chat/database/ChatLogQueries.java
@@ -82,7 +82,7 @@ public class ChatLogQueries {
     }
 
     public static CompletableFuture<Boolean> deleteOldMessages(Duration duration) {
-        String query = "DELETE FROM chat_log WHERE time_stamp > ?";
+        String query = "DELETE FROM chat_log WHERE time_stamp < ?";
 
         return CompletableFuture.supplyAsync(() -> {
             try (Connection connection = DatabaseConnection.getConnection()) {

--- a/api/src/main/java/com/alttd/chat/database/ChatLogQueries.java
+++ b/api/src/main/java/com/alttd/chat/database/ChatLogQueries.java
@@ -3,16 +3,12 @@ package com.alttd.chat.database;
 import com.alttd.chat.objects.chat_log.ChatLog;
 import com.alttd.chat.objects.chat_log.ChatLogHandler;
 import com.alttd.chat.util.ALogger;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.*;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
@@ -34,7 +30,7 @@ public class ChatLogQueries {
         }
     }
 
-    public static @NotNull CompletableFuture<Boolean> storeMessages(Object2ObjectOpenHashMap<UUID, List<ChatLog>> chatMessages) {
+    public static @NotNull CompletableFuture<Boolean> storeMessages(HashMap<UUID, List<ChatLog>> chatMessages) {
         String insertQuery = "INSERT INTO chat_log (uuid, time_stamp, server, chat_message, blocked) VALUES (?, ?, ?, ?, ?)";
         return CompletableFuture.supplyAsync(() -> {
             try (Connection connection = DatabaseConnection.createTransactionConnection()) {

--- a/api/src/main/java/com/alttd/chat/database/ChatLogQueries.java
+++ b/api/src/main/java/com/alttd/chat/database/ChatLogQueries.java
@@ -1,0 +1,102 @@
+package com.alttd.chat.database;
+
+import com.alttd.chat.objects.chat_log.ChatLog;
+import com.alttd.chat.objects.chat_log.ChatLogHandler;
+import com.alttd.chat.util.ALogger;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class ChatLogQueries {
+
+    protected static void createChatLogTable() {
+        String nicknamesTableQuery = "CREATE TABLE IF NOT EXISTS chat_log("
+                + "uuid CHAR(48) NOT NULL,"
+                + "time_stamp TIMESTAMP(6) NOT NULL, "
+                + "server VARCHAR(50) NOT NULL, "
+                + "chat_message VARCHAR(300) NOT NULL, "
+                + "blocked BIT(1) NOT NULL DEFAULT 0"
+                + ")";
+
+        try (PreparedStatement preparedStatement = DatabaseConnection.getConnection().prepareStatement(nicknamesTableQuery)) {
+            preparedStatement.executeUpdate();
+        } catch (Throwable throwable) {
+            ALogger.error("Failed to create chat log table", throwable);
+        }
+    }
+
+    public static @NotNull CompletableFuture<Boolean> storeMessages(Object2ObjectOpenHashMap<UUID, List<ChatLog>> chatMessages) {
+        String insertQuery = "INSERT INTO chat_log (uuid, time_stamp, server, chat_message, blocked) VALUES (?, ?, ?, ?, ?)";
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = DatabaseConnection.createTransactionConnection()) {
+                PreparedStatement preparedStatement = connection.prepareStatement(insertQuery);
+                for (List<ChatLog> chatLogList : chatMessages.values()) {
+                    for (ChatLog chatLog : chatLogList) {
+                        chatLog.prepareStatement(preparedStatement);
+                        preparedStatement.addBatch();
+                    }
+                }
+                int[] updatedRowsCount = preparedStatement.executeBatch();
+                boolean isSuccess = Arrays.stream(updatedRowsCount).allMatch(i -> i >= 0);
+
+                if (isSuccess) {
+                    connection.commit();
+                    return true;
+                } else {
+                    connection.rollback();
+                    ALogger.warn("Failed to store messages");
+                    return false;
+                }
+            } catch (SQLException sqlException) {
+                ALogger.error("Failed to store chat messages", sqlException);
+                throw new CompletionException("Failed to store chat messages", sqlException);
+            }
+        });
+    }
+
+    public static @NotNull CompletableFuture<List<ChatLog>> retrieveMessages(ChatLogHandler chatLogHandler, UUID uuid, Duration duration, String server) {
+        String query = "SELECT * FROM chat_log WHERE uuid = ? AND time_stamp > ? AND server = ?";
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = DatabaseConnection.getConnection()) {
+                PreparedStatement preparedStatement = connection.prepareStatement(query);
+                preparedStatement.setString(1, uuid.toString());
+                preparedStatement.setTimestamp(2, Timestamp.from(Instant.now().minus(duration)));
+                preparedStatement.setString(3, server);
+                ResultSet resultSet = preparedStatement.executeQuery();
+                List<ChatLog> chatLogs = new ArrayList<>();
+                while (resultSet.next()) {
+                    ChatLog chatLog = chatLogHandler.loadFromResultSet(resultSet);
+                    chatLogs.add(chatLog);
+                }
+                return chatLogs;
+            } catch (SQLException sqlException) {
+                ALogger.error(String.format("Failed to retrieve messages for user %s", uuid), sqlException);
+                throw new CompletionException(String.format("Failed to retrieve messages for user %s", uuid), sqlException);
+            }
+        });
+    }
+
+    public static CompletableFuture<Boolean> deleteOldMessages(Duration duration) {
+        String query = "DELETE FROM chat_log WHERE time_stamp > ?";
+
+        return CompletableFuture.supplyAsync(() -> {
+            try (Connection connection = DatabaseConnection.getConnection()) {
+                PreparedStatement preparedStatement = connection.prepareStatement(query);
+                preparedStatement.setTimestamp(1, Timestamp.from(Instant.now().minus(duration)));
+                return preparedStatement.execute();
+            } catch (SQLException sqlException) {
+                ALogger.error(String.format("Failed to delete messages older than %s days", duration.toDays()), sqlException);
+                throw new CompletionException(String.format("Failed to delete messages older than %s days", duration.toDays()), sqlException);
+            }
+        });
+    }
+}

--- a/api/src/main/java/com/alttd/chat/database/DatabaseConnection.java
+++ b/api/src/main/java/com/alttd/chat/database/DatabaseConnection.java
@@ -2,7 +2,6 @@ package com.alttd.chat.database;
 
 
 import com.alttd.chat.config.Config;
-import com.alttd.chat.util.ALogger;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -63,6 +62,21 @@ public class DatabaseConnection {
             e.printStackTrace();
         }
 
+        return connection;
+    }
+
+    /**
+     * Creates a transactional database connection.
+     *
+     * @return A {@code Connection} object representing the transactional database connection.
+     * @throws SQLException If there is an error creating the database connection.
+     */
+    public static Connection createTransactionConnection() throws SQLException {
+        connection = DriverManager.getConnection(
+                "jdbc:mysql://" + Config.IP + ":" + Config.PORT + "/" + Config.DATABASE + "?autoReconnect=true"+
+                        "&useSSL=false",
+                Config.USERNAME, Config.PASSWORD);
+        connection.setAutoCommit(false);
         return connection;
     }
 

--- a/api/src/main/java/com/alttd/chat/database/Queries.java
+++ b/api/src/main/java/com/alttd/chat/database/Queries.java
@@ -21,6 +21,7 @@ public class Queries {
         tables.add("CREATE TABLE IF NOT EXISTS mails (`id` INT NOT NULL AUTO_INCREMENT, `uuid` VARCHAR(36) NOT NULL, `sender` VARCHAR(36) NOT NULL, `message` VARCHAR(256) NOT NULL, `sendtime` BIGINT default 0, `readtime` BIGINT default 0, PRIMARY KEY (`id`))");
         createNicknamesTable();
         createRequestedNicknamesTable();
+        ChatLogQueries.createChatLogTable();
         try {
             Connection connection = DatabaseConnection.getConnection();
 

--- a/api/src/main/java/com/alttd/chat/objects/BatchInsertable.java
+++ b/api/src/main/java/com/alttd/chat/objects/BatchInsertable.java
@@ -1,0 +1,10 @@
+package com.alttd.chat.objects;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public interface BatchInsertable {
+
+    void prepareStatement(PreparedStatement preparedStatement) throws SQLException;
+
+}

--- a/api/src/main/java/com/alttd/chat/objects/chat_log/ChatLog.java
+++ b/api/src/main/java/com/alttd/chat/objects/chat_log/ChatLog.java
@@ -1,0 +1,52 @@
+package com.alttd.chat.objects.chat_log;
+
+import com.alttd.chat.objects.BatchInsertable;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+public class ChatLog implements BatchInsertable {
+
+    private final UUID uuid;
+    private final Instant timestamp;
+    private final String server;
+    private final String message;
+    private final boolean blocked;
+
+    protected ChatLog(UUID uuid, Instant timestamp, String server, String message, boolean blocked) {
+        this.uuid = uuid;
+        this.timestamp = timestamp;
+        this.server = server;
+        this.message = message;
+        this.blocked = blocked;
+    }
+
+    @Override
+    public void prepareStatement(@NotNull PreparedStatement preparedStatement) throws SQLException {
+        preparedStatement.setString(1, uuid.toString());
+        preparedStatement.setTimestamp(2, Timestamp.from(timestamp));
+        preparedStatement.setString(3, server);
+        preparedStatement.setString(4, message);
+        preparedStatement.setInt(5, blocked ? 1 : 0);
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isBlocked() {
+        return blocked;
+    }
+}

--- a/api/src/main/java/com/alttd/chat/objects/chat_log/ChatLogHandler.java
+++ b/api/src/main/java/com/alttd/chat/objects/chat_log/ChatLogHandler.java
@@ -28,8 +28,10 @@ public class ChatLogHandler {
     private final HashMap<UUID, List<ChatLog>> chatLogs = new HashMap<>();
 
     public ChatLogHandler(boolean enableLogging) {
-        if (!enableLogging)
+        if (!enableLogging) {
+            ALogger.info("Logging is not enabled on this server.");
             return;
+        }
         Duration deleteThreshold = Duration.ofDays(Config.CHAT_LOG_DELETE_OLDER_THAN_DAYS);
         ChatLogQueries.deleteOldMessages(deleteThreshold).thenAccept(success -> {
             if (success) {
@@ -41,6 +43,7 @@ public class ChatLogHandler {
         executorService = Executors.newSingleThreadScheduledExecutor();
         executorService.scheduleAtFixedRate(() -> saveToDatabase(false),
                 Config.CHAT_LOG_SAVE_DELAY_MINUTES, Config.CHAT_LOG_SAVE_DELAY_MINUTES, TimeUnit.MINUTES);
+        ALogger.info("Logging started!");
     }
 
     /**
@@ -78,6 +81,8 @@ public class ChatLogHandler {
         booleanCompletableFuture.whenComplete((result, throwable) -> {
             if (throwable == null && result) {
                 chatLogs.clear();
+            } else {
+                ALogger.error("Failed to save chat messages.");
             }
             savingToDatabase(false);
             while (!chatLogQueue.isEmpty()) {

--- a/api/src/main/java/com/alttd/chat/objects/chat_log/ChatLogHandler.java
+++ b/api/src/main/java/com/alttd/chat/objects/chat_log/ChatLogHandler.java
@@ -3,17 +3,13 @@ package com.alttd.chat.objects.chat_log;
 import com.alttd.chat.config.Config;
 import com.alttd.chat.database.ChatLogQueries;
 import com.alttd.chat.util.ALogger;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Queue;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.*;
 
 public class ChatLogHandler {
@@ -29,7 +25,7 @@ public class ChatLogHandler {
 
     private boolean isSaving;
     private final Queue<ChatLog> chatLogQueue = new ConcurrentLinkedQueue<>();
-    private final Object2ObjectOpenHashMap<UUID, List<ChatLog>> chatLogs = new Object2ObjectOpenHashMap<>();
+    private final HashMap<UUID, List<ChatLog>> chatLogs = new HashMap<>();
 
     public ChatLogHandler() {
         Duration deleteThreshold = Duration.ofDays(Config.CHAT_LOG_DELETE_OLDER_THAN_DAYS);

--- a/api/src/main/java/com/alttd/chat/objects/chat_log/ChatLogHandler.java
+++ b/api/src/main/java/com/alttd/chat/objects/chat_log/ChatLogHandler.java
@@ -1,0 +1,112 @@
+package com.alttd.chat.objects.chat_log;
+
+import com.alttd.chat.config.Config;
+import com.alttd.chat.database.ChatLogQueries;
+import com.alttd.chat.util.ALogger;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.*;
+
+public class ChatLogHandler {
+
+    private static ChatLogHandler instance = null;
+    private final ScheduledExecutorService executorService;
+
+    public static ChatLogHandler getInstance() {
+        if (instance == null)
+            instance = new ChatLogHandler();
+        return instance;
+    }
+
+    private boolean isSaving;
+    private final Queue<ChatLog> chatLogQueue = new ConcurrentLinkedQueue<>();
+    private final Object2ObjectOpenHashMap<UUID, List<ChatLog>> chatLogs = new Object2ObjectOpenHashMap<>();
+
+    public ChatLogHandler() {
+        Duration deleteThreshold = Duration.ofDays(Config.CHAT_LOG_DELETE_OLDER_THAN_DAYS);
+        ChatLogQueries.deleteOldMessages(deleteThreshold).thenAccept(success -> {
+            if (success) {
+                ALogger.info(String.format("Deleted all messages older than %s days from chat log database.", deleteThreshold.toDays()));
+            } else {
+                ALogger.warn(String.format("Failed to delete all messages older than %s days from chat log database.", deleteThreshold.toDays()));
+            }
+        });
+        executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService.scheduleAtFixedRate(() -> saveToDatabase(false),
+                Config.CHAT_LOG_SAVE_DELAY_MINUTES, Config.CHAT_LOG_SAVE_DELAY_MINUTES, TimeUnit.MINUTES);
+    }
+
+    public void shutDown() {
+        executorService.shutdown();
+        saveToDatabase(true);
+    }
+
+    private synchronized void savingToDatabase(boolean saving) {
+        isSaving = saving;
+    }
+
+    private synchronized boolean isBlocked() {
+        return isSaving;
+    }
+
+    public synchronized void addLog(ChatLog chatLog) {
+        if (isBlocked()) {
+            chatLogQueue.add(chatLog);
+        } else {
+            chatLogs.computeIfAbsent(chatLog.getUuid(), k -> new ArrayList<>()).add(chatLog);
+        }
+    }
+
+    private void saveToDatabase(boolean onMainThread) {
+        savingToDatabase(true);
+        CompletableFuture<Boolean> booleanCompletableFuture = ChatLogQueries.storeMessages(chatLogs);
+        if (onMainThread) {
+            booleanCompletableFuture.join();
+            return;
+        }
+        booleanCompletableFuture.whenComplete((result, throwable) -> {
+            if (throwable == null && result) {
+                chatLogs.clear();
+            }
+            savingToDatabase(false);
+            while (!chatLogQueue.isEmpty()) {
+                addLog(chatLogQueue.remove());
+            }
+        });
+    }
+
+    public ChatLog loadFromResultSet(@NotNull ResultSet resultSet) throws SQLException {
+        UUID chatLogUUID = UUID.fromString(resultSet.getString("uuid"));
+        Instant chatTimestamp = resultSet.getTimestamp("time_stamp").toInstant();
+        String server = resultSet.getString("server");
+        String chatMessage = resultSet.getString("chat_message");
+        boolean chatMessageBlocked = resultSet.getInt("blocked") == 1;
+        return new ChatLog(chatLogUUID, chatTimestamp, server, chatMessage, chatMessageBlocked);
+    }
+
+    public void addChatLog(UUID uuid, String server, String message, boolean blocked) {
+        addLog(new ChatLog(uuid, Instant.now(), server, message, blocked));
+    }
+
+    public CompletableFuture<List<ChatLog>> retrieveChatLogs(UUID uuid, Duration duration, String server) {
+        List<ChatLog> chatLogList = chatLogs.getOrDefault(uuid, new ArrayList<>());
+        return ChatLogQueries.retrieveMessages(this, uuid, duration, server)
+                .thenCompose(chatLogs -> CompletableFuture.supplyAsync(() -> {
+                    chatLogList.addAll(chatLogs);
+                    return chatLogList;
+                }))
+                .exceptionally(ex -> {
+                    throw new CompletionException(ex);
+                });
+    }
+
+}

--- a/galaxy/src/main/java/com/alttd/chat/ChatPlugin.java
+++ b/galaxy/src/main/java/com/alttd/chat/ChatPlugin.java
@@ -39,7 +39,7 @@ public class ChatPlugin extends JavaPlugin {
         chatHandler = new ChatHandler();
         DatabaseConnection.initialize();
         serverConfig = new ServerConfig(Bukkit.getServerName());
-        ChatLogHandler chatLogHandler = ChatLogHandler.getInstance();
+        ChatLogHandler chatLogHandler = ChatLogHandler.getInstance(true);
         registerListener(new PlayerListener(serverConfig), new ChatListener(chatLogHandler), new BookListener(), new ShutdownListener(chatLogHandler));
         if(serverConfig.GLOBALCHAT) {
             registerCommand("globalchat", new GlobalChat());

--- a/galaxy/src/main/java/com/alttd/chat/ChatPlugin.java
+++ b/galaxy/src/main/java/com/alttd/chat/ChatPlugin.java
@@ -40,7 +40,7 @@ public class ChatPlugin extends JavaPlugin {
         DatabaseConnection.initialize();
         serverConfig = new ServerConfig(Bukkit.getServerName());
         ChatLogHandler chatLogHandler = ChatLogHandler.getInstance(true);
-        registerListener(new PlayerListener(serverConfig), new ChatListener(chatLogHandler), new BookListener(), new ShutdownListener(chatLogHandler));
+        registerListener(new PlayerListener(serverConfig), new ChatListener(chatLogHandler), new BookListener(), new ShutdownListener(chatLogHandler, this));
         if(serverConfig.GLOBALCHAT) {
             registerCommand("globalchat", new GlobalChat());
             registerCommand("toggleglobalchat", new ToggleGlobalChat());

--- a/galaxy/src/main/java/com/alttd/chat/ChatPlugin.java
+++ b/galaxy/src/main/java/com/alttd/chat/ChatPlugin.java
@@ -5,14 +5,12 @@ import com.alttd.chat.config.Config;
 import com.alttd.chat.config.ServerConfig;
 import com.alttd.chat.database.DatabaseConnection;
 import com.alttd.chat.handler.ChatHandler;
-import com.alttd.chat.listeners.BookListener;
-import com.alttd.chat.listeners.ChatListener;
-import com.alttd.chat.listeners.PlayerListener;
-import com.alttd.chat.listeners.PluginMessage;
+import com.alttd.chat.listeners.*;
 import com.alttd.chat.nicknames.Nicknames;
 import com.alttd.chat.nicknames.NicknamesEvents;
 import com.alttd.chat.objects.channels.Channel;
 import com.alttd.chat.objects.channels.CustomChannel;
+import com.alttd.chat.objects.chat_log.ChatLogHandler;
 import com.alttd.chat.util.ALogger;
 import com.alttd.chat.util.Utility;
 import org.bukkit.Bukkit;
@@ -41,7 +39,8 @@ public class ChatPlugin extends JavaPlugin {
         chatHandler = new ChatHandler();
         DatabaseConnection.initialize();
         serverConfig = new ServerConfig(Bukkit.getServerName());
-        registerListener(new PlayerListener(serverConfig), new ChatListener(), new BookListener());
+        ChatLogHandler chatLogHandler = ChatLogHandler.getInstance();
+        registerListener(new PlayerListener(serverConfig), new ChatListener(chatLogHandler), new BookListener(), new ShutdownListener(chatLogHandler));
         if(serverConfig.GLOBALCHAT) {
             registerCommand("globalchat", new GlobalChat());
             registerCommand("toggleglobalchat", new ToggleGlobalChat());

--- a/galaxy/src/main/java/com/alttd/chat/listeners/ChatListener.java
+++ b/galaxy/src/main/java/com/alttd/chat/listeners/ChatListener.java
@@ -6,6 +6,7 @@ import com.alttd.chat.handler.ChatHandler;
 import com.alttd.chat.managers.ChatUserManager;
 import com.alttd.chat.managers.RegexManager;
 import com.alttd.chat.objects.*;
+import com.alttd.chat.objects.chat_log.ChatLogHandler;
 import com.alttd.chat.util.ALogger;
 import com.alttd.chat.util.GalaxyUtility;
 import com.alttd.chat.util.Utility;
@@ -37,6 +38,11 @@ import java.util.stream.Collectors;
 public class ChatListener implements Listener {
 
     private final PlainTextComponentSerializer plainTextComponentSerializer = PlainTextComponentSerializer.plainText();
+    private final ChatLogHandler chatLogHandler;
+
+    public ChatListener(ChatLogHandler chatLogHandler) {
+        this.chatLogHandler = chatLogHandler;
+    }
 
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -102,6 +108,7 @@ public class ChatListener implements Listener {
             GalaxyUtility.sendBlockedNotification("Language", player,
                     modifiableString.component(),
                     "");
+            chatLogHandler.addChatLog(player.getUniqueId(), player.getServer().getServerName(), PlainTextComponentSerializer.plainText().serialize(input), true);
             return; // the message was blocked
         }
 
@@ -115,6 +122,7 @@ public class ChatListener implements Listener {
         for (Player pingPlayer : playersToPing) {
             pingPlayer.playSound(pingPlayer.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS, 1, 1);
         }
+        chatLogHandler.addChatLog(player.getUniqueId(), player.getServer().getServerName(), modifiableString.string(), false);
         ALogger.info(PlainTextComponentSerializer.plainText().serialize(input));
     }
 

--- a/galaxy/src/main/java/com/alttd/chat/listeners/PlayerListener.java
+++ b/galaxy/src/main/java/com/alttd/chat/listeners/PlayerListener.java
@@ -11,6 +11,7 @@ import com.alttd.chat.objects.Toggleable;
 import com.alttd.chat.util.GalaxyUtility;
 import com.alttd.chat.util.Utility;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextReplacementConfig;
 import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -110,15 +111,29 @@ public class PlayerListener implements Listener {
         if (playerDeathsStack.size() > Config.DEATH_MESSAGES_MAX_PER_PERIOD || serverConfig.MUTED) {
             event.deathMessage(Component.empty());
             return;
-        } else {
-            Component component = event.deathMessage();
-            if (component != null) {
-                component = Component.text("* ").append(component);
-                component = component.style(Style.style(TextColor.color(82, 80, 77), TextDecoration.ITALIC));
-                event.deathMessage(component);
-            }
         }
+            Component component = event.deathMessage();
+
         playerDeathsStack.push(Instant.now());
+        if (component == null) {
+            return;
+        }
+        TextReplacementConfig playerReplacement = TextReplacementConfig.builder()
+                .match(event.getPlayer().getName())
+                .replacement(event.getPlayer().displayName())
+                .build();
+        component = component.replaceText(playerReplacement);
+        Player killer = event.getPlayer().getKiller();
+        if (killer != null) {
+            TextReplacementConfig killerReplacement = TextReplacementConfig.builder()
+                    .match(killer.getName())
+                    .replacement(killer.displayName())
+                    .build();
+            component = component.replaceText(killerReplacement);
+        }
+        component = MiniMessage.miniMessage().deserialize("<dark_red>[</dark_red><red>☠</red><dark_red>]</dark_red> ").append(component);
+        component = component.style(Style.style(TextColor.color(255, 155, 48), TextDecoration.ITALIC));
+        event.deathMessage(component);
     }
 
 }

--- a/galaxy/src/main/java/com/alttd/chat/listeners/ShutdownListener.java
+++ b/galaxy/src/main/java/com/alttd/chat/listeners/ShutdownListener.java
@@ -1,0 +1,21 @@
+package com.alttd.chat.listeners;
+
+import com.alttd.chat.objects.chat_log.ChatLogHandler;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.PluginDisableEvent;
+
+public class ShutdownListener implements Listener {
+
+    private final ChatLogHandler chatLogHandler;
+
+    public ShutdownListener(ChatLogHandler chatLogHandler) {
+        this.chatLogHandler = chatLogHandler;
+    }
+
+    @EventHandler
+    public void onShutdown(PluginDisableEvent event) {
+        chatLogHandler.shutDown();
+    }
+
+}

--- a/galaxy/src/main/java/com/alttd/chat/listeners/ShutdownListener.java
+++ b/galaxy/src/main/java/com/alttd/chat/listeners/ShutdownListener.java
@@ -4,17 +4,23 @@ import com.alttd.chat.objects.chat_log.ChatLogHandler;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.plugin.Plugin;
 
 public class ShutdownListener implements Listener {
 
     private final ChatLogHandler chatLogHandler;
+    private final Plugin thisPlugin;
 
-    public ShutdownListener(ChatLogHandler chatLogHandler) {
+    public ShutdownListener(ChatLogHandler chatLogHandler, Plugin thisPlugin) {
         this.chatLogHandler = chatLogHandler;
+        this.thisPlugin = thisPlugin;
     }
 
     @EventHandler
     public void onShutdown(PluginDisableEvent event) {
+        if (!event.getPlugin().getName().equals(thisPlugin.getName())){
+            return;
+        }
         chatLogHandler.shutDown();
     }
 

--- a/velocity/src/main/java/com/alttd/velocitychat/VelocityChat.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/VelocityChat.java
@@ -110,7 +110,7 @@ public class VelocityChat {
     }
 
     public void loadCommands() {
-        ChatLogHandler instance = ChatLogHandler.getInstance(); //TODO disable logging part
+        ChatLogHandler instance = ChatLogHandler.getInstance(false);
         new SilentJoinCommand(server);
         new GlobalAdminChat(server);
         new Reload(server);

--- a/velocity/src/main/java/com/alttd/velocitychat/VelocityChat.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/VelocityChat.java
@@ -5,6 +5,7 @@ import com.alttd.chat.ChatImplementation;
 import com.alttd.chat.managers.ChatUserManager;
 import com.alttd.chat.managers.PartyManager;
 import com.alttd.chat.objects.ChatUser;
+import com.alttd.chat.objects.chat_log.ChatLogHandler;
 import com.alttd.velocitychat.commands.*;
 import com.alttd.chat.config.Config;
 import com.alttd.chat.database.DatabaseConnection;
@@ -23,6 +24,7 @@ import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
@@ -108,12 +110,14 @@ public class VelocityChat {
     }
 
     public void loadCommands() {
+        ChatLogHandler instance = ChatLogHandler.getInstance(); //TODO disable logging part
         new SilentJoinCommand(server);
         new GlobalAdminChat(server);
         new Reload(server);
         new MailCommand(server);
         new Report(server);
-        new VoteToMute(server);
+        new VoteToMute(server, instance);
+        new VoteToMuteHelper(server);
         server.getCommandManager().register("party", new PartyCommand());
         // all (proxy)commands go here
     }

--- a/velocity/src/main/java/com/alttd/velocitychat/VelocityChat.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/VelocityChat.java
@@ -113,6 +113,7 @@ public class VelocityChat {
         new Reload(server);
         new MailCommand(server);
         new Report(server);
+        new VoteToMute(server);
         server.getCommandManager().register("party", new PartyCommand());
         // all (proxy)commands go here
     }

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMute.java
@@ -1,0 +1,160 @@
+package com.alttd.velocitychat.commands;
+
+import com.alttd.chat.config.Config;
+import com.alttd.chat.util.Utility;
+import com.alttd.velocitychat.commands.vote_to_mute.ActiveVoteToMute;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.velocitypowered.api.command.BrigadierCommand;
+import com.velocitypowered.api.command.CommandMeta;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.ServerConnection;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class VoteToMute {
+
+    public VoteToMute(ProxyServer proxyServer) {
+        RequiredArgumentBuilder<CommandSource, String> playerNode = RequiredArgumentBuilder
+                .<CommandSource, String>argument("player", StringArgumentType.string())
+                .suggests((context, builder) -> {
+                    List<Player> possiblePlayers;
+                    if (context.getSource() instanceof Player player) {
+                        Optional<ServerConnection> currentServer = player.getCurrentServer();
+                        if (currentServer.isPresent()) {
+                            possiblePlayers = getEligiblePlayers(currentServer.get().getServer());
+                        } else {
+                            possiblePlayers = getEligiblePlayers(proxyServer);
+                        }
+                    } else {
+                        possiblePlayers = getEligiblePlayers(proxyServer);
+                    }
+                    Collection<String> possibleValues = possiblePlayers.stream()
+                            .map(Player::getUsername)
+                            .toList();
+
+                    if (possibleValues.isEmpty())
+                        return Suggestions.empty();
+
+                    String remaining = builder.getRemaining().toLowerCase();
+                    possibleValues.stream()
+                            .filter(str -> str.toLowerCase().startsWith(remaining))
+                            .map(StringArgumentType::escapeIfRequired)
+                            .forEach(builder::suggest);
+                    return builder.buildFuture();
+                })
+                .executes(context -> {
+                    sendHelpMessage(context.getSource());
+                    return 1;
+                });
+
+        RequiredArgumentBuilder<CommandSource, String> yesNoNode = RequiredArgumentBuilder.
+                <CommandSource, String>argument("vote", StringArgumentType.string())
+                .suggests(((commandContext, suggestionsBuilder) -> {
+                    List<String> yesNoValues = Arrays.asList("yes", "no");
+                    String remaining = suggestionsBuilder.getRemaining().toLowerCase();
+                    yesNoValues.stream()
+                            .filter((String str) -> str.toLowerCase().startsWith(remaining))
+                            .map(StringArgumentType::escapeIfRequired)
+                            .forEach(suggestionsBuilder::suggest);
+                    return suggestionsBuilder.buildFuture();
+                }));
+
+        LiteralArgumentBuilder<CommandSource> voteNode = LiteralArgumentBuilder
+                .<CommandSource>literal("vote")
+                .then(playerNode
+                        .then(yesNoNode
+                                .executes(commandContext -> {
+                                    if (!(commandContext.getSource() instanceof Player)) {
+                                        commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                                "<red>Only players are allowed to vote</red>"));
+                                    }
+                                    Player source = (Player) commandContext.getSource();
+                                    String playerName = commandContext.getArgument("player", String.class);
+                                    Optional<ActiveVoteToMute> optionalActiveVoteToMute = ActiveVoteToMute.getInstance(playerName);
+                                    if (optionalActiveVoteToMute.isEmpty()) {
+                                        commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                                "<red>This player does not have an active vote to mute them</red>"));
+                                        return 1;
+                                    }
+                                    ActiveVoteToMute activeVoteToMute = optionalActiveVoteToMute.get();
+                                    String vote = commandContext.getArgument("vote", String.class);
+                                    switch (vote.toLowerCase()) {
+                                        case "yes" -> activeVoteToMute.vote(source.getUniqueId(), true);
+                                        case "no" -> activeVoteToMute.vote(source.getUniqueId(), false);
+                                        default -> commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                                "<red><vote> is not a valid vote option</red>", Placeholder.parsed("vote", vote)));
+                                    }
+                                    return 1;
+                                })).executes(context -> {
+                            sendHelpMessage(context.getSource());
+                            return 1;
+                        })).executes(context -> {
+                    sendHelpMessage(context.getSource());
+                    return 1;
+                });
+
+        LiteralCommandNode<CommandSource> command = LiteralArgumentBuilder
+                .<CommandSource>literal("votetomute")
+                .requires(commandSource -> commandSource.hasPermission("chat.vote-to-mute"))
+                .requires(commandSource -> commandSource instanceof Player)
+                .then(playerNode
+                        .executes(commandContext -> {
+                            String playerName = commandContext.getArgument("player", String.class);
+                            Optional<Player> optionalPlayer = proxyServer.getPlayer(playerName);
+                            if (optionalPlayer.isEmpty()) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                        "<red>Player <player> is not online</red>",
+                                        Placeholder.parsed("player", playerName)));
+                                return 1;
+                            }
+                            return 1;
+                        }))
+                .then(voteNode)
+                .executes(context -> {
+                    sendHelpMessage(context.getSource());
+                    return 1;
+                })
+                .build();
+        //TODO test command
+        //TODO add command to pick out the messages
+        //TODO add command to go to the next page
+
+        BrigadierCommand brigadierCommand = new BrigadierCommand(command);
+
+        CommandMeta.Builder metaBuilder = proxyServer.getCommandManager().metaBuilder(brigadierCommand);
+
+        CommandMeta meta = metaBuilder.build();
+
+        proxyServer.getCommandManager().register(meta, brigadierCommand);
+    }
+
+    private void sendHelpMessage(CommandSource commandSource) {
+        commandSource.sendMessage(Utility.parseMiniMessage("<red>Use: <gold>/votetomute <player></gold>.</red>"));
+    }
+
+    private List<Player> getEligiblePlayers(ProxyServer proxyServer) {
+        return proxyServer.getAllPlayers().stream()
+                .filter(player -> player.hasPermission("chat.affected-by-vote-to-mute"))
+                .collect(Collectors.toList());
+    }
+
+    private List<Player> getEligiblePlayers(RegisteredServer registeredServer) {
+        return registeredServer.getPlayersConnected().stream()
+                .filter(player -> player.hasPermission("chat.affected-by-vote-to-mute"))
+                .collect(Collectors.toList());
+
+    }
+
+}

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMute.java
@@ -104,6 +104,10 @@ public class VoteToMute {
                                 return 1;
                             }
                             RegisteredServer server = currentServer.get().getServer();
+                            if (currentServer.get().getServer().getPlayersConnected().stream().anyMatch(onlinePlayer -> onlinePlayer.hasPermission("chat.staff"))) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>There is a staff member online, so vote to mute can not be used. Please contact a staff member for help instead.</red>"));
+                                return 1;
+                            }
                             boolean countLowerRanks = false;
                             long count = getTotalEligiblePlayers(server, false);
                             if (count < 10) {

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMute.java
@@ -110,10 +110,10 @@ public class VoteToMute {
                             }
                             boolean countLowerRanks = false;
                             long count = getTotalEligiblePlayers(server, false);
-                            if (count < 10) {
+                            if (count < 6) {
                                 countLowerRanks = true;
                                 count = getTotalEligiblePlayers(server, true);
-                                if (count < 10) {
+                                if (count < 6) {
                                     commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>Not enough eligible players online to vote.</red>"));
                                     return 1;
                                 }

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMuteHelper.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMuteHelper.java
@@ -197,7 +197,7 @@ public class VoteToMuteHelper {
                                         }
                                     }
 
-                                    String vote = commandContext.getArgument("yesno", String.class);
+                                    String vote = commandContext.getArgument("yesNo", String.class);
                                     switch (vote.toLowerCase()) {
                                         case "yes" -> activeVoteToMute.vote(source.getUniqueId(), true);
                                         case "no" -> activeVoteToMute.vote(source.getUniqueId(), false);

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMuteHelper.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMuteHelper.java
@@ -1,0 +1,261 @@
+package com.alttd.velocitychat.commands;
+
+import com.alttd.chat.util.Utility;
+import com.alttd.velocitychat.commands.vote_to_mute.ActiveVoteToMute;
+import com.alttd.velocitychat.commands.vote_to_mute.VoteToMuteStarter;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.builder.RequiredArgumentBuilder;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.velocitypowered.api.command.BrigadierCommand;
+import com.velocitypowered.api.command.CommandMeta;
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.ServerConnection;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class VoteToMuteHelper {
+
+    public VoteToMuteHelper(ProxyServer proxyServer) {
+        RequiredArgumentBuilder<CommandSource, String> playerNode = RequiredArgumentBuilder
+                .<CommandSource, String>argument("player", StringArgumentType.string())
+                .suggests((context, builder) -> {
+                    List<Player> possiblePlayers;
+                    if (context.getSource() instanceof Player player) {
+                        Optional<ServerConnection> currentServer = player.getCurrentServer();
+                        if (currentServer.isPresent()) {
+                            possiblePlayers = getEligiblePlayers(currentServer.get().getServer());
+                        } else {
+                            possiblePlayers = getEligiblePlayers(proxyServer);
+                        }
+                    } else {
+                        possiblePlayers = getEligiblePlayers(proxyServer);
+                    }
+                    Collection<String> possibleValues = possiblePlayers.stream()
+                            .map(Player::getUsername)
+                            .toList();
+
+                    if (possibleValues.isEmpty())
+                        return Suggestions.empty();
+
+                    String remaining = builder.getRemaining().toLowerCase();
+                    possibleValues.stream()
+                            .filter(str -> str.toLowerCase().startsWith(remaining))
+                            .map(StringArgumentType::escapeIfRequired)
+                            .forEach(builder::suggest);
+                    return builder.buildFuture();
+                })
+                .executes(context -> {
+                    sendHelpMessage(context.getSource());
+                    return 1;
+                });
+
+        RequiredArgumentBuilder<CommandSource, String> yesNoNode = RequiredArgumentBuilder.
+                <CommandSource, String>argument("yesNo", StringArgumentType.string())
+                .suggests(((commandContext, suggestionsBuilder) -> {
+                    List<String> yesNoValues = Arrays.asList("yes", "no");
+                    String remaining = suggestionsBuilder.getRemaining().toLowerCase();
+                    yesNoValues.stream()
+                            .filter((String str) -> str.toLowerCase().startsWith(remaining))
+                            .map(StringArgumentType::escapeIfRequired)
+                            .forEach(suggestionsBuilder::suggest);
+                    return suggestionsBuilder.buildFuture();
+                }));
+
+        LiteralArgumentBuilder<CommandSource> pageNode = LiteralArgumentBuilder
+                .<CommandSource>literal("page")
+                .requires(commandSource -> commandSource.hasPermission("chat.vote-to-mute"))
+                .then(RequiredArgumentBuilder.<CommandSource, Integer>argument("page number", IntegerArgumentType.integer(1))
+                        .suggests(((commandContext, suggestionsBuilder) -> {
+                            if (!(commandContext.getSource() instanceof Player player)) {
+                                return suggestionsBuilder.buildFuture();
+                            }
+                            Optional<VoteToMuteStarter> instance = VoteToMuteStarter.getInstance(player.getUniqueId());
+                            if (instance.isEmpty()) {
+                                return suggestionsBuilder.buildFuture();
+                            }
+                            VoteToMuteStarter voteToMuteStarter = instance.get();
+                            String remaining = suggestionsBuilder.getRemaining().toLowerCase();
+                            int totalPages = voteToMuteStarter.getTotalPages();
+                            IntStream.range(1, totalPages + 1)
+                                    .mapToObj(String::valueOf)
+                                    .filter((String str) -> str.toLowerCase().startsWith(remaining))
+                                    .map(StringArgumentType::escapeIfRequired)
+                                    .forEach(suggestionsBuilder::suggest);
+                            return suggestionsBuilder.buildFuture();
+                        }))
+                        .executes(commandContext -> {
+                            if (!(commandContext.getSource() instanceof Player player)) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>Only players can use this command.</red>"));
+                                return 1;
+                            }
+                            Optional<VoteToMuteStarter> instance = VoteToMuteStarter.getInstance(player.getUniqueId());
+                            if (instance.isEmpty()) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>You don't have an active vote to mute.</red>"));
+                                return 1;
+                            }
+                            int pageNumber = commandContext.getArgument("page number", Integer.class);
+                            instance.get().showPage(pageNumber);
+                            return 1;
+                        })
+                ).executes(commandContext -> {
+                    sendHelpMessage(commandContext.getSource());
+                    return 1;
+                });
+
+        LiteralArgumentBuilder<CommandSource> enterPageNode = LiteralArgumentBuilder
+                .<CommandSource>literal("messages")
+                .requires(commandSource -> commandSource.hasPermission("chat.vote-to-mute"))
+                .then(RequiredArgumentBuilder.<CommandSource, String>argument("list of messages", StringArgumentType.greedyString())
+                        .executes(commandContext -> {
+                            if (!(commandContext.getSource() instanceof Player player)) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>Only players can use this command.</red>"));
+                                return 1;
+                            }
+                            Optional<VoteToMuteStarter> instance = VoteToMuteStarter.getInstance(player.getUniqueId());
+                            if (instance.isEmpty()) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>You don't have an active vote to mute.</red>"));
+                                return 1;
+                            }
+                            String listOfPages = commandContext.getArgument("list of messages", String.class);
+                            if (!listOfPages.matches("([1-9][0-9]*, )*[1-9][0-9]*")) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>Please make sure to format the command correctly.</red>"));
+                                return 1;
+                            }
+                            VoteToMuteStarter voteToMuteStarter = instance.get();
+
+                            List<Integer> collect = Arrays.stream(listOfPages.split(", "))
+                                    .map(Integer::parseInt)
+                                    .collect(Collectors.toList());
+                            Optional<Integer> max = collect.stream().max(Integer::compare);
+                            if (max.isEmpty()) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>Some of your selected messages do not exist.</red>"));
+                                return 1;
+                            }
+                            int highestLogEntry = max.get();
+
+                            if (voteToMuteStarter.getTotalLogEntries() > highestLogEntry) {
+                                commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>Some of your selected messages do not exist.</red>"));
+                                return 1;
+                            }
+
+                            Optional<ServerConnection> currentServer = player.getCurrentServer();
+                            if (currentServer.isEmpty()) {
+                                sendHelpMessage(commandContext.getSource());
+                                return 1;
+                            }
+
+                            Component chatLogs = voteToMuteStarter.getChatLogsAndClose(collect);
+                            RegisteredServer server = currentServer.get().getServer();
+                            long count = getTotalEligiblePlayers(server, voteToMuteStarter.countLowerRanks());
+                            new ActiveVoteToMute(voteToMuteStarter.getVotedPlayer(), server, proxyServer, Duration.ofMinutes(5),
+                                    (int) count, voteToMuteStarter.countLowerRanks(), chatLogs)
+                                    .start();
+                            return 1;
+                        })
+                ).executes(commandContext -> {
+                    sendHelpMessage(commandContext.getSource());
+                    return 1;
+                });
+
+        LiteralArgumentBuilder<CommandSource> voteNode = LiteralArgumentBuilder
+                .<CommandSource>literal("vote")
+                .then(playerNode
+                        .then(yesNoNode
+                                .executes(commandContext -> {
+                                    if (!(commandContext.getSource() instanceof Player)) {
+                                        commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                                "<red>Only players are allowed to vote</red>"));
+                                    }
+                                    Player source = (Player) commandContext.getSource();
+                                    String playerName = commandContext.getArgument("player", String.class);
+                                    Optional<ActiveVoteToMute> optionalActiveVoteToMute = ActiveVoteToMute.getInstance(playerName);
+                                    if (optionalActiveVoteToMute.isEmpty()) {
+                                        commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                                "<red>This player does not have an active vote to mute them.</red>"));
+                                        return 1;
+                                    }
+                                    ActiveVoteToMute activeVoteToMute = optionalActiveVoteToMute.get();
+
+                                    if (!activeVoteToMute.countLowerRanks()) {
+                                        if (!source.hasPermission("chat.vote-to-mute")) {
+                                            source.sendMessage(Utility.parseMiniMessage("<red>You are not eligible to vote.</red>"));
+                                            return 1;
+                                        }
+                                    }
+
+                                    String vote = commandContext.getArgument("yesno", String.class);
+                                    switch (vote.toLowerCase()) {
+                                        case "yes" -> activeVoteToMute.vote(source.getUniqueId(), true);
+                                        case "no" -> activeVoteToMute.vote(source.getUniqueId(), false);
+                                        default -> commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                                "<red><vote> is not a valid vote option</red>", Placeholder.parsed("vote", vote)));
+                                    }
+                                    return 1;
+                                })).executes(context -> {
+                            sendHelpMessage(context.getSource());
+                            return 1;
+                        })).executes(context -> {
+                    sendHelpMessage(context.getSource());
+                    return 1;
+                });
+
+        LiteralCommandNode<CommandSource> command = LiteralArgumentBuilder
+                .<CommandSource>literal("votetomutehelper")
+                .requires(commandSource -> commandSource.hasPermission("chat.backup-vote-to-mute"))
+                .requires(commandSource -> commandSource instanceof Player)
+                .then(voteNode)
+                .then(pageNode)
+                .then(enterPageNode)
+                .executes(context -> {
+                    sendHelpMessage(context.getSource());
+                    return 1;
+                })
+                .build();
+
+        BrigadierCommand brigadierCommand = new BrigadierCommand(command);
+
+        CommandMeta.Builder metaBuilder = proxyServer.getCommandManager().metaBuilder(brigadierCommand);
+
+        CommandMeta meta = metaBuilder.build();
+
+        proxyServer.getCommandManager().register(meta, brigadierCommand);
+    }
+
+    private int getTotalEligiblePlayers(RegisteredServer server, boolean countLowerRanks) {
+        return (int) server.getPlayersConnected().stream()
+                .filter(player -> countLowerRanks ? player.hasPermission("chat.backup-vote-to-mute") : player.hasPermission("chat.vote-to-mute"))
+                .count();
+    }
+
+    private void sendHelpMessage(CommandSource commandSource) {
+        commandSource.sendMessage(Utility.parseMiniMessage("<red>Use: <gold>/votetomutehelper <player></gold>.</red>"));
+    }
+
+    private List<Player> getEligiblePlayers(ProxyServer proxyServer) {
+        return proxyServer.getAllPlayers().stream()
+                .filter(player -> player.hasPermission("chat.affected-by-vote-to-mute"))
+                .collect(Collectors.toList());
+    }
+
+    private List<Player> getEligiblePlayers(RegisteredServer registeredServer) {
+        return registeredServer.getPlayersConnected().stream()
+                .filter(player -> player.hasPermission("chat.affected-by-vote-to-mute"))
+                .collect(Collectors.toList());
+
+    }
+
+}

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMuteHelper.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMuteHelper.java
@@ -150,7 +150,7 @@ public class VoteToMuteHelper {
                             }
                             int highestLogEntry = max.get();
 
-                            if (voteToMuteStarter.getTotalLogEntries() > highestLogEntry) {
+                            if (voteToMuteStarter.getTotalLogEntries() < highestLogEntry) {
                                 commandContext.getSource().sendMessage(Utility.parseMiniMessage("<red>Some of your selected messages do not exist.</red>"));
                                 return 1;
                             }

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMuteHelper.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/VoteToMuteHelper.java
@@ -116,7 +116,7 @@ public class VoteToMuteHelper {
                     return 1;
                 });
 
-        LiteralArgumentBuilder<CommandSource> enterPageNode = LiteralArgumentBuilder
+        LiteralArgumentBuilder<CommandSource> enterMessagesNode = LiteralArgumentBuilder
                 .<CommandSource>literal("messages")
                 .requires(commandSource -> commandSource.hasPermission("chat.vote-to-mute"))
                 .then(RequiredArgumentBuilder.<CommandSource, String>argument("list of messages", StringArgumentType.greedyString())
@@ -199,8 +199,16 @@ public class VoteToMuteHelper {
 
                                     String vote = commandContext.getArgument("yesNo", String.class);
                                     switch (vote.toLowerCase()) {
-                                        case "yes" -> activeVoteToMute.vote(source.getUniqueId(), true);
-                                        case "no" -> activeVoteToMute.vote(source.getUniqueId(), false);
+                                        case "yes" -> {
+                                            activeVoteToMute.vote(source.getUniqueId(), true);
+                                            commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                                    "<green>You voted to mute. Thanks for voting, staff will be online soon to review!</green>"));
+                                        }
+                                        case "no" -> {
+                                            activeVoteToMute.vote(source.getUniqueId(), false);
+                                            commandContext.getSource().sendMessage(Utility.parseMiniMessage(
+                                                    "<green>You voted <red>not</red> to mute. Thanks for voting, staff will be online soon to review!</green>"));
+                                        }
                                         default -> commandContext.getSource().sendMessage(Utility.parseMiniMessage(
                                                 "<red><vote> is not a valid vote option</red>", Placeholder.parsed("vote", vote)));
                                     }
@@ -219,7 +227,7 @@ public class VoteToMuteHelper {
                 .requires(commandSource -> commandSource instanceof Player)
                 .then(voteNode)
                 .then(pageNode)
-                .then(enterPageNode)
+                .then(enterMessagesNode)
                 .executes(context -> {
                     sendHelpMessage(context.getSource());
                     return 1;

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
@@ -127,7 +127,7 @@ public class ActiveVoteToMute {
 
     public boolean votePassed() {
         double totalVotes = (votedFor.size() + votedAgainst.size());
-        if (totalVotes == 0) {
+        if (totalVotes == 0 || votedFor.isEmpty()) {
             return false;
         }
         if (totalVotes / totalEligibleVoters < 0.6) {

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
@@ -1,0 +1,81 @@
+package com.alttd.velocitychat.commands.vote_to_mute;
+
+import com.alttd.chat.util.Utility;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.UUID;
+
+public class ActiveVoteToMute {
+
+    private static final HashMap<String, ActiveVoteToMute> instances = new HashMap<>();
+    private static final Component prefix = Utility.parseMiniMessage("<gold>[VoteMute]</gold>");
+
+    private final Instant start;
+    private final Player votedPlayer;
+    private final Duration duration;
+    private HashSet<UUID> votedFor = new HashSet<>();
+    private HashSet<UUID> votedAgainst = new HashSet<>();
+    private int totalEligibleVoters;
+
+    public static Optional<ActiveVoteToMute> getInstance(String username) {
+        if (!instances.containsKey(username))
+            return Optional.empty();
+        return Optional.of(instances.get(username));
+    }
+
+    public ActiveVoteToMute(@NotNull Player votedPlayer, Duration duration, int totalEligibleVoters) {
+        this.start = Instant.now();
+        this.votedPlayer = votedPlayer;
+        this.duration = duration;
+        this.totalEligibleVoters = totalEligibleVoters;
+        instances.put(votedPlayer.getUsername(), this);
+    }
+
+    public void start(@NotNull RegisteredServer registeredServer, Component chatLogs) {
+        Component message = Utility.parseMiniMessage(
+                String.format("""
+                        <prefix> <gold>[VoteMute]</gold> <green>A vote to mute <player> for one hour has been started, please read the logs below before voting.</green>
+                        <logs>
+                        <prefix> Click: <click:run_command:'/votetomute vote %s yes'><red>Mute</red></click> --- <click:run_command:'/votetomute vote %s no'><yellow>Don't mute</yellow></click>""",
+                        votedPlayer.getUsername(), votedPlayer.getUsername()),
+                Placeholder.component("prefix", prefix),
+                Placeholder.parsed("player", votedPlayer.getUsername()),
+                Placeholder.component("logs", chatLogs));
+        registeredServer.getPlayersConnected().stream()
+                .filter(player -> player.hasPermission("chat.vote-to-mute"))
+                .forEach(player -> player.sendMessage(message));
+    }
+
+    public void vote(UUID uuid, boolean votedToMute) {
+        if (votedToMute) {
+            votedFor.add(uuid);
+            votedAgainst.remove(uuid);
+        } else {
+            votedAgainst.add(uuid);
+            votedFor.remove(uuid);
+        }
+    }
+
+    public boolean votePassed() {
+        double totalVotes = (votedFor.size() + votedAgainst.size());
+        if (totalVotes / totalEligibleVoters  < 0.6) {
+            return false;
+        }
+        return votedFor.size() / totalVotes > 0.6;
+    }
+
+    public boolean voteEnded() {
+        if (votedFor.size() + votedAgainst.size() == totalEligibleVoters)
+            return true;
+        return duration.minus(Duration.between(start, Instant.now())).isNegative();
+    }
+}

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
@@ -35,6 +35,7 @@ public class ActiveVoteToMute {
     private final RegisteredServer server;
     private final ProxyServer proxyServer;
     private final Component chatLogs;
+    private boolean endedVote = false;
 
     public static Optional<ActiveVoteToMute> getInstance(String username) {
         if (!instances.containsKey(username))
@@ -91,6 +92,8 @@ public class ActiveVoteToMute {
     }
 
     private void endVote() {
+        if (endedVote)
+            return;
         instances.remove(votedPlayer.getUsername());
         if (votePassed()) {
             mutePlayer();
@@ -117,6 +120,7 @@ public class ActiveVoteToMute {
             if (!votePassed()) {
                 return;
             }
+            endedVote = true;
             instances.remove(votedPlayer.getUsername());
             mutePlayer();
         } else {
@@ -206,7 +210,7 @@ public class ActiveVoteToMute {
     private Component getVoteStartMessage() {
         return Utility.parseMiniMessage(
                 String.format("""
-                        <prefix> <gold>[VoteMute]</gold> <green>A vote to mute <player> for one hour has been started, please read the logs below before voting.</green>
+                        <prefix> <green>A vote to mute <player> for one hour has been started, please read the logs below before voting.</green>
                         <logs>
                         <prefix> Click: <click:run_command:'/votetomutehelper vote %s yes'><red>Mute</red></click> --- <click:run_command:'/votetomutehelper vote %s no'><yellow>Don't mute</yellow></click>""",
                         votedPlayer.getUsername(), votedPlayer.getUsername()),

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
@@ -1,14 +1,19 @@
 package com.alttd.velocitychat.commands.vote_to_mute;
 
+import com.alttd.chat.config.Config;
 import com.alttd.chat.util.Utility;
+import com.alttd.proxydiscordlink.DiscordLink;
+import com.alttd.proxydiscordlink.lib.net.dv8tion.jda.api.EmbedBuilder;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.jetbrains.annotations.NotNull;
 
+import java.awt.*;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -141,6 +146,22 @@ public class ActiveVoteToMute {
                 .forEach(player -> player.sendMessage(message));
         proxyServer.getCommandManager().executeAsync(proxyServer.getConsoleCommandSource(),
                 String.format("tempmute %s 1h Muted by the community - under review.", votedPlayer.getUsername()));
+
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+        embedBuilder.setAuthor(votedPlayer.getUsername(), null, "https://crafatar.com/avatars/" + votedPlayer.getUniqueId() + "?overlay");
+        embedBuilder.setTitle("Player muted by vote");
+        embedBuilder.setColor(Color.CYAN);
+        String chatLogsString = PlainTextComponentSerializer.plainText().serialize(chatLogs);
+        embedBuilder.addField("Logs",
+                chatLogsString.substring(0, Math.min(chatLogsString.length(), 1024)),
+                false);
+        embedBuilder.addField("Server",
+                server.getServerInfo().getName().substring(0, 1).toUpperCase() + server.getServerInfo().getName().substring(1),
+                false);
+
+        long id = Config.serverChannelId.get("general");
+        DiscordLink.getPlugin().getBot().sendEmbedToDiscord(id, embedBuilder, -1);
     }
 
     public void addEligibleVoter(Player player) {

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
@@ -2,29 +2,35 @@ package com.alttd.velocitychat.commands.vote_to_mute;
 
 import com.alttd.chat.util.Utility;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public class ActiveVoteToMute {
 
     private static final HashMap<String, ActiveVoteToMute> instances = new HashMap<>();
     private static final Component prefix = Utility.parseMiniMessage("<gold>[VoteMute]</gold>");
 
-    private final Instant start;
     private final Player votedPlayer;
-    private final Duration duration;
     private HashSet<UUID> votedFor = new HashSet<>();
     private HashSet<UUID> votedAgainst = new HashSet<>();
     private int totalEligibleVoters;
+    private final boolean countLowerRanks;
+    private final RegisteredServer server;
+    private final ProxyServer proxyServer;
+    private final Component chatLogs;
 
     public static Optional<ActiveVoteToMute> getInstance(String username) {
         if (!instances.containsKey(username))
@@ -32,26 +38,71 @@ public class ActiveVoteToMute {
         return Optional.of(instances.get(username));
     }
 
-    public ActiveVoteToMute(@NotNull Player votedPlayer, Duration duration, int totalEligibleVoters) {
-        this.start = Instant.now();
-        this.votedPlayer = votedPlayer;
-        this.duration = duration;
-        this.totalEligibleVoters = totalEligibleVoters;
-        instances.put(votedPlayer.getUsername(), this);
+    public static void removePotentialVoter(Player player, RegisteredServer previousServer) {
+        if (!player.hasPermission("chat.backup-vote-to-mute"))
+            return;
+        if (player.hasPermission("chat.vote-to-mute")) {
+            instances.values().stream()
+                    .filter(activeVoteToMute -> previousServer == null || activeVoteToMute.getServer().getServerInfo().hashCode() == previousServer.getServerInfo().hashCode())
+                    .forEach(inst -> inst.removeEligibleVoter(player.getUniqueId()));
+        } else {
+            instances.values().stream()
+                    .filter(ActiveVoteToMute::countLowerRanks)
+                    .filter(activeVoteToMute -> previousServer == null || activeVoteToMute.getServer().getServerInfo().hashCode() == previousServer.getServerInfo().hashCode())
+                    .forEach(inst -> inst.removeEligibleVoter(player.getUniqueId()));
+        }
     }
 
-    public void start(@NotNull RegisteredServer registeredServer, Component chatLogs) {
-        Component message = Utility.parseMiniMessage(
-                String.format("""
-                        <prefix> <gold>[VoteMute]</gold> <green>A vote to mute <player> for one hour has been started, please read the logs below before voting.</green>
-                        <logs>
-                        <prefix> Click: <click:run_command:'/votetomute vote %s yes'><red>Mute</red></click> --- <click:run_command:'/votetomute vote %s no'><yellow>Don't mute</yellow></click>""",
-                        votedPlayer.getUsername(), votedPlayer.getUsername()),
-                Placeholder.component("prefix", prefix),
-                Placeholder.parsed("player", votedPlayer.getUsername()),
-                Placeholder.component("logs", chatLogs));
-        registeredServer.getPlayersConnected().stream()
-                .filter(player -> player.hasPermission("chat.vote-to-mute"))
+    public static void addPotentialVoter(Player player, ServerConnection server) {
+        if (!player.hasPermission("chat.backup-vote-to-mute"))
+            return;
+        if (player.hasPermission("chat.vote-to-mute")) {
+            instances.values().stream()
+                    .filter(activeVoteToMute -> activeVoteToMute.getServer().getServerInfo().hashCode() == server.getServerInfo().hashCode())
+                    .forEach(activeVoteToMute -> activeVoteToMute.addEligibleVoter(player));
+        } else {
+            instances.values().stream()
+                    .filter(ActiveVoteToMute::countLowerRanks)
+                    .filter(activeVoteToMute -> activeVoteToMute.getServer().getServerInfo().hashCode() == server.getServerInfo().hashCode())
+                    .forEach(activeVoteToMute -> activeVoteToMute.addEligibleVoter(player));
+        }
+    }
+
+    public ActiveVoteToMute(@NotNull Player votedPlayer, @NotNull RegisteredServer server, ProxyServer proxyServer, Duration duration,
+                            int totalEligibleVoters, boolean countLowerRanks, Component chatLogs) {
+        this.chatLogs = chatLogs;
+        this.votedPlayer = votedPlayer;
+        this.totalEligibleVoters = totalEligibleVoters;
+        this.countLowerRanks = countLowerRanks;
+        this.server = server;
+        this.proxyServer = proxyServer;
+        instances.put(votedPlayer.getUsername(), this);
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService.schedule(this::endVote,
+                duration.toMinutes(), TimeUnit.MINUTES);
+    }
+
+    private RegisteredServer getServer() {
+        return server;
+    }
+
+    private void endVote() {
+        instances.remove(votedPlayer.getUsername());
+        if (votePassed()) {
+            mutePlayer();
+            return;
+        }
+        Component message = Utility.parseMiniMessage("<prefix> <red>The vote to mute <player> has failed, they will not be muted.</green>",
+                Placeholder.component("prefix", prefix), Placeholder.parsed("player", votedPlayer.getUsername()));
+        server.getPlayersConnected().stream()
+                .filter(player -> countLowerRanks ? player.hasPermission("chat.backup-vote-to-mute") : player.hasPermission("chat.vote-to-mute"))
+                .forEach(player -> player.sendMessage(message));
+    }
+
+    public void start() {
+        Component message = getVoteStartMessage();
+        server.getPlayersConnected().stream()
+                .filter(player -> countLowerRanks ? player.hasPermission("chat.backup-vote-to-mute") : player.hasPermission("chat.vote-to-mute"))
                 .forEach(player -> player.sendMessage(message));
     }
 
@@ -59,6 +110,11 @@ public class ActiveVoteToMute {
         if (votedToMute) {
             votedFor.add(uuid);
             votedAgainst.remove(uuid);
+            if (!votePassed()) {
+                return;
+            }
+            instances.remove(votedPlayer.getUsername());
+            mutePlayer();
         } else {
             votedAgainst.add(uuid);
             votedFor.remove(uuid);
@@ -73,9 +129,43 @@ public class ActiveVoteToMute {
         return votedFor.size() / totalVotes > 0.6;
     }
 
-    public boolean voteEnded() {
-        if (votedFor.size() + votedAgainst.size() == totalEligibleVoters)
-            return true;
-        return duration.minus(Duration.between(start, Instant.now())).isNegative();
+    public boolean countLowerRanks() {
+        return countLowerRanks;
+    }
+
+    private void mutePlayer() {
+        Component message = Utility.parseMiniMessage("<prefix> <green>The vote to mute <player> has passed, they will be muted.</green>",
+                Placeholder.component("prefix", prefix), Placeholder.parsed("player", votedPlayer.getUsername()));
+        server.getPlayersConnected().stream()
+                .filter(player -> countLowerRanks ? player.hasPermission("chat.backup-vote-to-mute") : player.hasPermission("chat.vote-to-mute"))
+                .forEach(player -> player.sendMessage(message));
+        proxyServer.getCommandManager().executeAsync(proxyServer.getConsoleCommandSource(),
+                String.format("tempmute %s 1h Muted by the community - under review.", votedPlayer.getUsername()));
+    }
+
+    public void addEligibleVoter(Player player) {
+        UUID uuid = player.getUniqueId();
+        if (votedAgainst.contains(uuid) || votedFor.contains(uuid))
+            return;
+        totalEligibleVoters++;
+        player.sendMessage(getVoteStartMessage());
+    }
+
+    public void removeEligibleVoter(UUID uuid) {
+        if (votedFor.contains(uuid) || votedAgainst.contains(uuid))
+            return;
+        totalEligibleVoters--;
+    }
+
+    private Component getVoteStartMessage() {
+        return Utility.parseMiniMessage(
+                String.format("""
+                        <prefix> <gold>[VoteMute]</gold> <green>A vote to mute <player> for one hour has been started, please read the logs below before voting.</green>
+                        <logs>
+                        <prefix> Click: <click:run_command:'/votetomutehelper vote %s yes'><red>Mute</red></click> --- <click:run_command:'/votetomutehelper vote %s no'><yellow>Don't mute</yellow></click>""",
+                        votedPlayer.getUsername(), votedPlayer.getUsername()),
+                Placeholder.component("prefix", prefix),
+                Placeholder.parsed("player", votedPlayer.getUsername()),
+                Placeholder.component("logs", chatLogs));
     }
 }

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/ActiveVoteToMute.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.NotNull;
 import java.awt.*;
 import java.time.Duration;
 import java.util.*;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -97,7 +96,7 @@ public class ActiveVoteToMute {
             mutePlayer();
             return;
         }
-        Component message = Utility.parseMiniMessage("<prefix> <red>The vote to mute <player> has failed, they will not be muted.</green>",
+        Component message = Utility.parseMiniMessage("<prefix> <red>The vote to mute <player> has failed, they will not be muted.</red>",
                 Placeholder.component("prefix", prefix), Placeholder.parsed("player", votedPlayer.getUsername()));
         server.getPlayersConnected().stream()
                 .filter(player -> countLowerRanks ? player.hasPermission("chat.backup-vote-to-mute") : player.hasPermission("chat.vote-to-mute"))
@@ -128,7 +127,10 @@ public class ActiveVoteToMute {
 
     public boolean votePassed() {
         double totalVotes = (votedFor.size() + votedAgainst.size());
-        if (totalVotes / totalEligibleVoters  < 0.6) {
+        if (totalVotes == 0) {
+            return false;
+        }
+        if (totalVotes / totalEligibleVoters < 0.6) {
             return false;
         }
         return votedFor.size() / totalVotes > 0.6;

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
@@ -1,0 +1,110 @@
+package com.alttd.velocitychat.commands.vote_to_mute;
+
+import com.alttd.chat.objects.chat_log.ChatLog;
+import com.alttd.chat.objects.chat_log.ChatLogHandler;
+import com.alttd.chat.util.Utility;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class VoteToMuteStarter {
+
+    private static final HashMap<UUID, VoteToMuteStarter> instanceMap = new HashMap<>();
+
+    private static final Component prefix = Utility.parseMiniMessage("<gold>[VoteMute]</gold>");
+    private final ChatLogHandler chatLogHandler;
+    private final Player votedPlayer;
+    private final Player commandSource;
+    private final String serverName;
+    private List<Component> parsedChatLogs;
+
+    public static Optional<VoteToMuteStarter> getInstance(UUID uuid) {
+        if (!instanceMap.containsKey(uuid))
+            return Optional.empty();
+        return Optional.of(instanceMap.get(uuid));
+    }
+
+    public VoteToMuteStarter(ChatLogHandler chatLogHandler, Player votedPlayer, Player commandSource, String serverName) {
+        this.chatLogHandler = chatLogHandler;
+        this.votedPlayer = votedPlayer;
+        this.commandSource = commandSource;
+        this.serverName = serverName;
+        instanceMap.put(commandSource.getUniqueId(), this);
+    }
+
+    public void start() {
+        chatLogHandler.retrieveChatLogs(votedPlayer.getUniqueId(), Duration.ofMinutes(5), serverName).whenCompleteAsync((chatLogs, throwable) -> {
+            if (throwable != null) {
+                commandSource.sendMessage(Utility.parseMiniMessage("<prefix> <red>Unable to retrieve messages</red> for player <player>",
+                        Placeholder.component("prefix", prefix),
+                        Placeholder.parsed("player", votedPlayer.getUsername())));
+                return;
+            }
+            parseChatLogs(chatLogs);
+            commandSource.sendMessage(Utility.parseMiniMessage(
+                    "<prefix> <green>Please select up to 10 messages other players should see to decide their vote, seperated by comma's. " +
+                            "Example: <gold>/votetomute messages 1, 2, 5, 8</gold></green>"));
+            showPage(0);
+        });
+    }
+
+    private void parseChatLogs(List<ChatLog> chatLogs) {
+        TagResolver.Single playerTag = Placeholder.parsed("player", votedPlayer.getUsername());
+        chatLogs.sort(Comparator.comparing(ChatLog::getTimestamp));
+        parsedChatLogs = IntStream.range(0, chatLogs.size())
+                .mapToObj(i -> Utility.parseMiniMessage(
+                        "<number>. [ChatLog] <player>: <message>",
+                        TagResolver.resolver(
+                                Placeholder.unparsed("message", chatLogs.get(i).getMessage()),
+                                Placeholder.parsed("number", String.valueOf(i + 1)),
+                                playerTag
+                        ))
+                )
+                .toList();
+    }
+
+    public void showPage(int page) {
+        List<Component> collect = parsedChatLogs.stream().skip(page * 10L).limit(page).toList();
+        Component chatLogsComponent = Component.join(JoinConfiguration.newlines(), collect);
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("<prefix> ChatLogs for <player>\n<logs>\n");
+        if (page != 0) {
+            stringBuilder.append("<click:run_command:/votetomute page ")
+                    .append(page - 1)
+                    .append("><hover:show_text:'<gold>Click to go to previous page'><gold><previous page></gold></hover></click> ");
+        }
+        if (parsedChatLogs.size() > page * 10) {
+            stringBuilder.append("<click:run_command:/votetomute page ")
+                    .append(page + 1)
+                    .append("><hover:show_text:'<gold>Click to go to next page'><gold><previous page></gold></hover></click> ");
+        }
+        commandSource.sendMessage(Utility.parseMiniMessage(stringBuilder.toString(),
+                Placeholder.parsed("player", votedPlayer.getUsername()),
+                Placeholder.component("prefix", prefix),
+                Placeholder.component("logs", chatLogsComponent)));
+    }
+
+    /**
+     * Retrieves the chat logs for the given list of IDs. It removes 1 from the IDs before using them
+     * It removes the instance from the hashmap after this function call
+     *
+     * @param ids A list of integers representing the IDs of the chat logs to retrieve.
+     * @return A Component object containing the selected chat logs joined by newlines.
+     */
+    public Component getChatLogsAndClose(List<Integer> ids) {
+        List<Component> selectedChatLogs = ids.stream()
+                .filter(id -> id >= 1 && id <= parsedChatLogs.size())
+                .map(id -> parsedChatLogs.get(id - 1))
+                .collect(Collectors.toList());
+
+        instanceMap.remove(commandSource.getUniqueId());
+        return Component.join(JoinConfiguration.newlines(), selectedChatLogs);
+    }
+}

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
@@ -73,19 +73,19 @@ public class VoteToMuteStarter {
     }
 
     public void showPage(int page) {
-        List<Component> collect = parsedChatLogs.stream().skip(page * 10L).limit(page).toList();
+        List<Component> collect = parsedChatLogs.stream().skip((page - 1) * 10L).limit(10L).toList();
         Component chatLogsComponent = Component.join(JoinConfiguration.newlines(), collect);
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("<prefix> ChatLogs for <player>\n<logs>\n");
-        if (page != 0) {
-            stringBuilder.append("<click:run_command:/votetomute page ")
+        if (page > 1) {
+            stringBuilder.append("<click:run_command:/votetomutehelper page ")
                     .append(page - 1)
                     .append("><hover:show_text:'<gold>Click to go to previous page'><gold><previous page></gold></hover></click> ");
         }
         if (parsedChatLogs.size() > page * 10) {
-            stringBuilder.append("<click:run_command:/votetomute page ")
+            stringBuilder.append("<click:run_command:/votetomutehelper page ")
                     .append(page + 1)
-                    .append("><hover:show_text:'<gold>Click to go to next page'><gold><previous page></gold></hover></click> ");
+                    .append("><hover:show_text:'<gold>Click to go to next page'><gold><next page></gold></hover></click> ");
         }
         commandSource.sendMessage(Utility.parseMiniMessage(stringBuilder.toString(),
                 Placeholder.parsed("player", votedPlayer.getUsername()),

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
@@ -42,7 +42,7 @@ public class VoteToMuteStarter {
     }
 
     public void start() {
-        chatLogHandler.retrieveChatLogs(votedPlayer.getUniqueId(), Duration.ofMinutes(5), serverName).whenCompleteAsync((chatLogs, throwable) -> {
+        chatLogHandler.retrieveChatLogs(votedPlayer.getUniqueId(), Duration.ofMinutes(10), serverName).whenCompleteAsync((chatLogs, throwable) -> {
             if (throwable != null) {
                 commandSource.sendMessage(Utility.parseMiniMessage("<prefix> <red>Unable to retrieve messages</red> for player <player>",
                         Placeholder.component("prefix", prefix),
@@ -59,14 +59,15 @@ public class VoteToMuteStarter {
 
     private void parseChatLogs(List<ChatLog> chatLogs) {
         TagResolver.Single playerTag = Placeholder.parsed("player", votedPlayer.getUsername());
+        TagResolver.Single prefixTag = Placeholder.component("prefix", prefix);
         chatLogs.sort(Comparator.comparing(ChatLog::getTimestamp));
         parsedChatLogs = IntStream.range(0, chatLogs.size())
                 .mapToObj(i -> Utility.parseMiniMessage(
-                        "<number>. [ChatLog] <player>: <message>",
+                        "<number>. <prefix> <player>: <message>",
                         TagResolver.resolver(
                                 Placeholder.unparsed("message", chatLogs.get(i).getMessage()),
                                 Placeholder.parsed("number", String.valueOf(i + 1)),
-                                playerTag
+                                playerTag, prefixTag
                         ))
                 )
                 .toList();

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
@@ -60,7 +60,7 @@ public class VoteToMuteStarter {
     private void parseChatLogs(List<ChatLog> chatLogs) {
         TagResolver.Single playerTag = Placeholder.parsed("player", votedPlayer.getUsername());
         TagResolver.Single prefixTag = Placeholder.component("prefix", prefix);
-        chatLogs.sort(Comparator.comparing(ChatLog::getTimestamp));
+        chatLogs.sort(Comparator.comparing(ChatLog::getTimestamp).reversed());
         parsedChatLogs = IntStream.range(0, chatLogs.size())
                 .mapToObj(i -> Utility.parseMiniMessage(
                         "<number>. <prefix> <player>: <message>",

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
@@ -52,8 +52,8 @@ public class VoteToMuteStarter {
             parseChatLogs(chatLogs);
             commandSource.sendMessage(Utility.parseMiniMessage(
                     "<prefix> <green>Please select up to 10 messages other players should see to decide their vote, seperated by comma's. " +
-                            "Example: <gold>/votetomutehelper messages 1, 2, 5, 8</gold></green>"));
-            showPage(0);
+                            "Example: <gold>/votetomutehelper messages 1, 2, 5, 8</gold></green>", Placeholder.component("prefix", prefix)));
+            showPage(1);
         });
     }
 

--- a/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
+++ b/velocity/src/main/java/com/alttd/velocitychat/commands/vote_to_mute/VoteToMuteStarter.java
@@ -24,6 +24,7 @@ public class VoteToMuteStarter {
     private final Player commandSource;
     private final String serverName;
     private List<Component> parsedChatLogs;
+    private final boolean countLowerRanks;
 
     public static Optional<VoteToMuteStarter> getInstance(UUID uuid) {
         if (!instanceMap.containsKey(uuid))
@@ -31,11 +32,12 @@ public class VoteToMuteStarter {
         return Optional.of(instanceMap.get(uuid));
     }
 
-    public VoteToMuteStarter(ChatLogHandler chatLogHandler, Player votedPlayer, Player commandSource, String serverName) {
+    public VoteToMuteStarter(ChatLogHandler chatLogHandler, Player votedPlayer, Player commandSource, String serverName, boolean countLowerRanks) {
         this.chatLogHandler = chatLogHandler;
         this.votedPlayer = votedPlayer;
         this.commandSource = commandSource;
         this.serverName = serverName;
+        this.countLowerRanks = countLowerRanks;
         instanceMap.put(commandSource.getUniqueId(), this);
     }
 
@@ -50,7 +52,7 @@ public class VoteToMuteStarter {
             parseChatLogs(chatLogs);
             commandSource.sendMessage(Utility.parseMiniMessage(
                     "<prefix> <green>Please select up to 10 messages other players should see to decide their vote, seperated by comma's. " +
-                            "Example: <gold>/votetomute messages 1, 2, 5, 8</gold></green>"));
+                            "Example: <gold>/votetomutehelper messages 1, 2, 5, 8</gold></green>"));
             showPage(0);
         });
     }
@@ -106,5 +108,21 @@ public class VoteToMuteStarter {
 
         instanceMap.remove(commandSource.getUniqueId());
         return Component.join(JoinConfiguration.newlines(), selectedChatLogs);
+    }
+
+    public int getTotalPages() {
+        return (int) Math.ceil((double) parsedChatLogs.size() / 10);
+    }
+
+    public Player getVotedPlayer() {
+        return votedPlayer;
+    }
+
+    public int getTotalLogEntries() {
+        return parsedChatLogs.size();
+    }
+
+    public boolean countLowerRanks() {
+        return countLowerRanks;
     }
 }


### PR DESCRIPTION
This adds chat log functionality, by default logs will be saved for 31 days.

This adds the votetomute and votetomutehelper commands. These commands can be used by certain players to vote to mute other players. The players that can do the voting and the ones that can be voted on are determined by the permissions chat.vote-to-mute (+ chat.backup-vote-to-mute) and chat.affected-by-vote-to-mute. There have to be at least 10 elligable voters. Preference is given to vote-to-mute users, but if there aren't enough of those online the players with the backup-vote-to-mute permission will also be considered eligible to vote.

Votes aren't possible when staff are online. If a vote succeeds a report is made in the staff discord in #general. Votes end after 5 minutes