### PR TITLE
Ignore fix

### DIFF
--- a/galaxy/src/main/java/com/alttd/chat/handler/ChatHandler.java
+++ b/galaxy/src/main/java/com/alttd/chat/handler/ChatHandler.java
@@ -26,6 +26,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 public class ChatHandler {
 
@@ -239,10 +240,17 @@ public class ChatHandler {
     private void sendChatChannelMessage(CustomChannel chatChannel, UUID uuid, Component component) {
         if (!chatChannel.getServers().contains(Bukkit.getServerName())) return;
 
-        Bukkit.getServer().getOnlinePlayers().stream()
-                .filter(p -> p.hasPermission(chatChannel.getPermission()))
-                .filter(p -> !ChatUserManager.getChatUser(p.getUniqueId()).getIgnoredPlayers().contains(uuid))
-                .forEach(p -> p.sendMessage(component));
+        Player player = Bukkit.getPlayer(uuid);
+        if (player == null) {
+            return;
+        }
+
+        Stream<? extends Player> stream = Bukkit.getServer().getOnlinePlayers().stream()
+                .filter(p -> p.hasPermission(chatChannel.getPermission()));
+        if (!player.hasPermission("chat.ignorebypass")) {
+            stream = stream.filter(p -> !ChatUserManager.getChatUser(p.getUniqueId()).getIgnoredPlayers().contains(uuid) && !p.hasPermission("chat.ignorebypass"));
+        }
+        stream.forEach(p -> p.sendMessage(component));
     }
 
     private void sendPluginMessage(Player player, String channel, Component component) {

--- a/galaxy/src/main/java/com/alttd/chat/listeners/PluginMessage.java
+++ b/galaxy/src/main/java/com/alttd/chat/listeners/PluginMessage.java
@@ -15,7 +15,6 @@ import com.alttd.chat.util.Utility;
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteStreams;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
@@ -46,7 +45,7 @@ public class PluginMessage implements PluginMessageListener {
                     break;
                 }
                 ChatUser chatUser = ChatUserManager.getChatUser(uuid);
-                if (!chatUser.getIgnoredPlayers().contains(targetuuid)) {
+                if (isTargetNotIgnored(chatUser, targetuuid)) {
                     player.sendMessage(GsonComponentSerializer.gson().deserialize(message));
                     player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS, 1, 1); // todo load this from config
                     ChatUser user = ChatUserManager.getChatUser(uuid);
@@ -64,7 +63,7 @@ public class PluginMessage implements PluginMessageListener {
                     break;
                 }
                 ChatUser chatUser = ChatUserManager.getChatUser(uuid);
-                if (!chatUser.getIgnoredPlayers().contains(targetuuid)) {
+                if (isTargetNotIgnored(chatUser, targetuuid)) {
                     chatUser.setReplyTarget(target);
                     player.sendMessage(GsonComponentSerializer.gson().deserialize(message));
 //                        ChatUser user = ChatUserManager.getChatUser(uuid);
@@ -80,7 +79,7 @@ public class PluginMessage implements PluginMessageListener {
 
                 Bukkit.getOnlinePlayers().stream().filter(p -> p.hasPermission(Config.GCPERMISSION)).forEach(p -> {
                     ChatUser chatUser = ChatUserManager.getChatUser(p.getUniqueId());
-                    if (!chatUser.getIgnoredPlayers().contains(uuid)) {
+                    if (isTargetNotIgnored(chatUser, uuid)) {
                         p.sendMessage(GsonComponentSerializer.gson().deserialize(message));
                     }
                 });
@@ -216,6 +215,17 @@ public class PluginMessage implements PluginMessageListener {
                         .forEach(p -> p.sendMessage(finalComponent));
             }
         }.runTaskAsynchronously(ChatPlugin.getInstance());
+    }
+
+    private boolean isTargetNotIgnored(ChatUser chatUser, UUID targetUUID) {
+        if (!chatUser.getIgnoredPlayers().contains(targetUUID)) {
+            return true;
+        }
+        Player target = Bukkit.getPlayer(targetUUID);
+        if (target == null) {
+            return true;
+        }
+        return target.hasPermission("chat.ignorebypass");
     }
 
 }

--- a/galaxy/src/main/java/com/alttd/chat/listeners/PluginMessage.java
+++ b/galaxy/src/main/java/com/alttd/chat/listeners/PluginMessage.java
@@ -22,13 +22,14 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 public class PluginMessage implements PluginMessageListener {
 
     @Override
-    public void onPluginMessageReceived(String channel, Player player, byte[] bytes) {
+    public void onPluginMessageReceived(String channel, @NotNull Player ignored, byte[] bytes) {
         if (!channel.equals(Config.MESSAGECHANNEL)) {
             return;
         }
@@ -38,35 +39,36 @@ public class PluginMessage implements PluginMessageListener {
             case "privatemessagein": {
                 UUID uuid = UUID.fromString(in.readUTF());
                 String target = in.readUTF();
-                Player p = Bukkit.getPlayer(uuid);
+                Player player = Bukkit.getPlayer(uuid);
                 String message = in.readUTF();
                 UUID targetuuid = UUID.fromString(in.readUTF());
-                if (p != null) {
-                    ChatUser chatUser = ChatUserManager.getChatUser(uuid);
-                    if (!chatUser.getIgnoredPlayers().contains(targetuuid)) {
-                        p.sendMessage(GsonComponentSerializer.gson().deserialize(message));
-                        p.playSound(p.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS, 1, 1); // todo load this from config
-                        ChatUser user = ChatUserManager.getChatUser(uuid);
-                        if (!user.getReplyContinueTarget().equalsIgnoreCase(target))
-                            user.setReplyTarget(target);
-                    }
+                if (player == null) {
+                    break;
                 }
-                break;
+                ChatUser chatUser = ChatUserManager.getChatUser(uuid);
+                if (!chatUser.getIgnoredPlayers().contains(targetuuid)) {
+                    player.sendMessage(GsonComponentSerializer.gson().deserialize(message));
+                    player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS, 1, 1); // todo load this from config
+                    ChatUser user = ChatUserManager.getChatUser(uuid);
+                    if (!user.getReplyContinueTarget().equalsIgnoreCase(target))
+                        user.setReplyTarget(target);
+                }
             }
             case "privatemessageout": {
                 UUID uuid = UUID.fromString(in.readUTF());
                 String target = in.readUTF();
-                Player p = Bukkit.getPlayer(uuid);
+                Player player = Bukkit.getPlayer(uuid);
                 String message = in.readUTF();
                 UUID targetuuid = UUID.fromString(in.readUTF());
-                if (p != null) {
-                    ChatUser chatUser = ChatUserManager.getChatUser(uuid);
-                    if (!chatUser.getIgnoredPlayers().contains(targetuuid)) {
-                        chatUser.setReplyTarget(target);
-                        p.sendMessage(GsonComponentSerializer.gson().deserialize(message));
+                if (player == null) {
+                    break;
+                }
+                ChatUser chatUser = ChatUserManager.getChatUser(uuid);
+                if (!chatUser.getIgnoredPlayers().contains(targetuuid)) {
+                    chatUser.setReplyTarget(target);
+                    player.sendMessage(GsonComponentSerializer.gson().deserialize(message));
 //                        ChatUser user = ChatUserManager.getChatUser(uuid);
 //                        user.setReplyTarget(target);
-                    }
                 }
                 break;
             }


### PR DESCRIPTION
Don't ignore users with bypass permission

Refactored chat logic to respect 'chat.ignorebypass' permission for both senders and receivers. This only applies to cases where a user is sending text to another user, checks for login/out messages were not fixed